### PR TITLE
fix tgt build issue

### DIFF
--- a/dynamic-layers/openstack-layer/recipes-support/tgt/files/fix-undefined-reference-to-major.patch
+++ b/dynamic-layers/openstack-layer/recipes-support/tgt/files/fix-undefined-reference-to-major.patch
@@ -1,0 +1,26 @@
+Fix undefined reference to major:
+
+Error:
+-- snip --
+/opt/work_jagadeesh/speed_bsps/opencgx-renesas-2.6/project/tmp/work/aarch64-montavista-linux/tgt/1.0.67+gitAUTOINC+cb7971cfee-r0/recipe-sysroot-native/usr/bin/aarch64-montavista-linux/../../libexec/aarch64-montavista-linux/gcc/aarch64-montavista-linux/8.2.0/ld: bs_sg.o: in function `chk_sg_device':
+/usr/src/debug/tgt/1.0.67+gitAUTOINC+cb7971cfee-r0/git/usr/bs_sg.c:354: undefined reference to `major'
+/opt/work_jagadeesh/speed_bsps/opencgx-renesas-2.6/project/tmp/work/aarch64-montavista-linux/tgt/1.0.67+gitAUTOINC+cb7971cfee-r0/recipe-sysroot-native/usr/bin/aarch64-montavista-linux/../../libexec/aarch64-montavista-linux/gcc/aarch64-montavista-linux/8.2.0/ld: /usr/src/debug/tgt/1.0.67+gitAUTOINC+cb7971cfee-r0/git/usr/bs_sg.c:358: undefined reference to `major'
+collect2: error: ld returned 1 exit status
+-- snip --
+
+Upstream-Status: Pending
+
+Signed-off-by: Jagadeesh Krishnanjanappa <jkrishnanjanappa@mvista.com>
+
+diff --git a/usr/bs_sg.c b/usr/bs_sg.c
+index 66f4a3b..6d03aa4 100644
+--- a/usr/bs_sg.c
++++ b/usr/bs_sg.c
+@@ -35,6 +35,7 @@
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <sys/epoll.h>
++#include <sys/sysmacros.h>
+ #include <scsi/sg.h>
+ 
+ #include "bsg.h" /* Copied from include/linux/bsg.h */

--- a/dynamic-layers/openstack-layer/recipes-support/tgt/tgt_mvista.inc
+++ b/dynamic-layers/openstack-layer/recipes-support/tgt/tgt_mvista.inc
@@ -1,1 +1,5 @@
+PR .= ".1"
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += "file://fix-undefined-reference-to-major.patch"
+
 DEPENDS += "libaio"


### PR DESCRIPTION
Source: MontaVista Software, LLC
MR: 00000
Type: Defect Fix
Disposition: Local
Description:

Solves below error:
-- snip --
ERROR: oe_runmake failed
/opt/work_jagadeesh/speed_bsps/opencgx-renesas-2.6/project/tmp/work/aarch64-montavista-linux/tgt/1.0.67+gitAUTOINC+cb7971cfee-r0/recipe-sysroot-native/usr/bin/aarch64-montavista-linux/../../libexec/aarch64-montavista-linux/gcc/aarch64-montavista-linux/8.2.0/ld: bs_sg.o: in function `chk_sg_device':
/usr/src/debug/tgt/1.0.67+gitAUTOINC+cb7971cfee-r0/git/usr/bs_sg.c:354: undefined reference to `major'
/opt/work_jagadeesh/speed_bsps/opencgx-renesas-2.6/project/tmp/work/aarch64-montavista-linux/tgt/1.0.67+gitAUTOINC+cb7971cfee-r0/recipe-sysroot-native/usr/bin/aarch64-montavista-linux/../../libexec/aarch64-montavista-linux/gcc/aarch64-montavista-linux/8.2.0/ld: /usr/src/debug/tgt/1.0.67+gitAUTOINC+cb7971cfee-r0/git/usr/bs_sg.c:358: undefined reference to `major'
collect2: error: ld returned 1 exit status
-- snip --

Signed-off-by: Jagadeesh Krishnanjanappa <jkrishnanjanappa@mvista.com>